### PR TITLE
exclude also ext miss values in ifcond

### DIFF
--- a/dev/Statistics/RandomTrialRegression/rctreg.ado
+++ b/dev/Statistics/RandomTrialRegression/rctreg.ado
@@ -79,7 +79,7 @@ syntax varlist using [if/] [in], controls(varlist) treatment(varlist) [sd] [titl
 	if "`if'" != "" local ifif if
 	
 	foreach var in `morevars' `controls' {
-		local ifcond `" `ifcond' & `var' != . "'
+		local ifcond `" `ifcond' & `var' < . "'
 		}
 		
 	* Lag control


### PR DESCRIPTION
In the current state it only excludes observations that has the traditional missing value . and not the extended missing variables .a, .b etc. 

Feel free to dismiss this PR if I am missing a reason for why only traditional missing values should be excluded.